### PR TITLE
Update SvgTextElement constructor

### DIFF
--- a/SvgNet/Elements/SvgTextElement.cs
+++ b/SvgNet/Elements/SvgTextElement.cs
@@ -57,7 +57,15 @@ namespace SvgNet.SvgElements {
             AddChild(tn);
         }
 
+                [Obsolete()]
         public SvgTextElement(string s, float x, float y) {
+            var tn = new TextNode(s);
+            AddChild(tn);
+            X = x;
+            Y = y;
+        }
+
+        public SvgTextElement(string s, SvgLength x, SvgLength y) {
             var tn = new TextNode(s);
             AddChild(tn);
             X = x;


### PR DESCRIPTION
The constructor that accepts two floats for X and Y is implicitly converting to SvgLength objects with unknown length types. A new constructor is added to accept the correct parameter types.